### PR TITLE
Fix ReadResponse nil Bug

### DIFF
--- a/json_response.go
+++ b/json_response.go
@@ -82,8 +82,10 @@ func ReadResponse(r io.Reader, v interface{}) error {
 	if u.Error != nil {
 		return u.Error
 	}
-	if err := json.Unmarshal(u.Data, v); err != nil {
-		return fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
+	if v != nil {
+		if err := json.Unmarshal(u.Data, v); err != nil {
+			return fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
+		}
 	}
 	return nil
 }

--- a/json_response_test.go
+++ b/json_response_test.go
@@ -159,3 +159,29 @@ func TestReadResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestReadResponseNil(t *testing.T) {
+	type TestStruct struct {
+		Value string
+	}
+
+	tests := []struct {
+		name      string
+		r         io.Reader
+		wantErr   bool
+		wantValue string
+	}{
+		{"Empty", bytes.NewReader(nil), true, ""},
+		{"Nil", getResponseBody(nil), false, "blah"},
+		{"Response", getResponseBody(TestStruct{"blah"}), false, "blah"},
+		{"Error", getErrorBody("blah", http.StatusNotFound), true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ReadResponse(tt.r, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix bug when `nil` passed to `ReadResponse()`. This is useful when no `data` is expected on success, since `error` may still contain detail on failure.