### PR TITLE
Paged Responses

### DIFF
--- a/json_response.go
+++ b/json_response.go
@@ -19,6 +19,12 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("%v %v", e.Code, http.StatusText(e.Code))
 }
 
+// PageDetails specifies paging information.
+type PageDetails struct {
+	Prev string `json:"prev,omitempty"`
+	Next string `json:"next,omitempty"`
+}
+
 // Error describes an error condition.
 type Error struct {
 	Code    int    `json:"code,omitempty"`
@@ -27,8 +33,9 @@ type Error struct {
 
 // Response is the top level container of all of our REST API responses.
 type Response struct {
-	Data  interface{} `json:"data,omitempty"`
-	Error *Error      `json:"error,omitempty"`
+	Data  interface{}  `json:"data,omitempty"`
+	Page  *PageDetails `json:"page,omitempty"`
+	Error *Error       `json:"error,omitempty"`
 }
 
 // NewError returns an error that contains the given code and message.
@@ -56,13 +63,14 @@ func WriteError(w http.ResponseWriter, error string, code int) error {
 	return nil
 }
 
-// WriteResponse encodes the supplied data in a response, and writes to w.
-func WriteResponse(w http.ResponseWriter, data interface{}, code int) error {
+// WriteResponsePage encodes the supplied data in a paged JSON response, and writes to w.
+func WriteResponsePage(w http.ResponseWriter, data interface{}, pd *PageDetails, code int) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 
 	jr := Response{
 		Data: data,
+		Page: pd,
 	}
 	if err := json.NewEncoder(w).Encode(jr); err != nil {
 		return fmt.Errorf("jsonresp: failed to write response: %v", err)
@@ -70,22 +78,34 @@ func WriteResponse(w http.ResponseWriter, data interface{}, code int) error {
 	return nil
 }
 
-// ReadResponse reads a JSON response, and unmarshals the supplied data.
-func ReadResponse(r io.Reader, v interface{}) error {
+// ReadResponsePage reads a paged JSON response, and unmarshals the supplied data.
+func ReadResponsePage(r io.Reader, v interface{}) (pd *PageDetails, err error) {
 	var u struct {
 		Data  json.RawMessage `json:"data"`
+		Page  *PageDetails    `json:"page"`
 		Error *Error          `json:"error"`
 	}
 	if err := json.NewDecoder(r).Decode(&u); err != nil {
-		return fmt.Errorf("jsonresp: failed to read response: %v", err)
+		return nil, fmt.Errorf("jsonresp: failed to read response: %v", err)
 	}
 	if u.Error != nil {
-		return u.Error
+		return nil, u.Error
 	}
 	if v != nil {
 		if err := json.Unmarshal(u.Data, v); err != nil {
-			return fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
+			return nil, fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
 		}
 	}
-	return nil
+	return u.Page, nil
+}
+
+// WriteResponse encodes the supplied data in a response, and writes to w.
+func WriteResponse(w http.ResponseWriter, data interface{}, code int) error {
+	return WriteResponsePage(w, data, nil, code)
+}
+
+// ReadResponse reads a JSON response, and unmarshals the supplied data.
+func ReadResponse(r io.Reader, v interface{}) error {
+	_, err := ReadResponsePage(r, v)
+	return err
 }

--- a/json_response_test.go
+++ b/json_response_test.go
@@ -79,6 +79,59 @@ func TestWriteError(t *testing.T) {
 	}
 }
 
+func TestWriteResponsePage(t *testing.T) {
+	type TestStruct struct {
+		Value string
+	}
+
+	tests := []struct {
+		name      string
+		data      interface{}
+		pd        *PageDetails
+		code      int
+		wantValue string
+		wantPD    *PageDetails
+		wantCode  int
+	}{
+		{"Empty", TestStruct{""}, nil, http.StatusOK, "", nil, http.StatusOK},
+		{"NotEmpty", TestStruct{"blah"}, nil, http.StatusOK, "blah", nil, http.StatusOK},
+		{"PageNone", TestStruct{"blah"}, &PageDetails{}, http.StatusOK, "blah", &PageDetails{}, http.StatusOK},
+		{"PagePrev", TestStruct{"blah"}, &PageDetails{Prev: "p"}, http.StatusOK, "blah", &PageDetails{Prev: "p"}, http.StatusOK},
+		{"PageNext", TestStruct{"blah"}, &PageDetails{Next: "n"}, http.StatusOK, "blah", &PageDetails{Next: "n"}, http.StatusOK},
+		{"PagePrevNext", TestStruct{"blah"}, &PageDetails{Prev: "p", Next: "n"}, http.StatusOK, "blah", &PageDetails{Prev: "p", Next: "n"}, http.StatusOK},
+		{"Created", TestStruct{"blah"}, nil, http.StatusCreated, "blah", nil, http.StatusCreated},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+
+			WriteResponsePage(rr, tt.data, tt.pd, tt.code)
+
+			var ts TestStruct
+			pd, err := ReadResponsePage(rr.Body, &ts)
+			if err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if ts.Value != tt.wantValue {
+				t.Errorf("got value '%v', want '%v'", ts.Value, tt.wantValue)
+			}
+			if got, want := (pd == nil), (tt.wantPD == nil); got != want {
+				t.Errorf("got nil page %v, want %v", got, want)
+			} else if pd != nil {
+				if got, want := pd.Prev, tt.wantPD.Prev; got != want {
+					t.Errorf("got prev %v, want %v", got, want)
+				}
+				if got, want := pd.Next, tt.wantPD.Next; got != want {
+					t.Errorf("got next %v, want %v", got, want)
+				}
+			}
+			if rr.Code != tt.wantCode {
+				t.Errorf("got code '%v', want '%v'", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
 func TestWriteResponse(t *testing.T) {
 	type TestStruct struct {
 		Value string
@@ -115,16 +168,68 @@ func TestWriteResponse(t *testing.T) {
 	}
 }
 
-func getResponseBody(v interface{}) io.Reader {
+func getResponseBodyPage(v interface{}, p *PageDetails) io.Reader {
 	rr := httptest.NewRecorder()
-	WriteResponse(rr, v, http.StatusOK)
+	WriteResponsePage(rr, v, p, http.StatusOK)
 	return rr.Body
+}
+
+func getResponseBody(v interface{}) io.Reader {
+	return getResponseBodyPage(v, nil)
 }
 
 func getErrorBody(error string, code int) io.Reader {
 	rr := httptest.NewRecorder()
 	WriteError(rr, error, code)
 	return rr.Body
+}
+
+func TestReadResponsePage(t *testing.T) {
+	type TestStruct struct {
+		Value string
+	}
+
+	tests := []struct {
+		name      string
+		r         io.Reader
+		wantErr   bool
+		wantValue string
+		wantPD    *PageDetails
+	}{
+		{"Empty", bytes.NewReader(nil), true, "", nil},
+		{"Response", getResponseBody(TestStruct{"blah"}), false, "blah", nil},
+		{"ResponsePageNone", getResponseBodyPage(TestStruct{"blah"}, &PageDetails{}), false, "blah", &PageDetails{}},
+		{"ResponsePagePrev", getResponseBodyPage(TestStruct{"blah"}, &PageDetails{"prev", ""}), false, "blah", &PageDetails{Prev: "prev"}},
+		{"ResponsePageNext", getResponseBodyPage(TestStruct{"blah"}, &PageDetails{"", "next"}), false, "blah", &PageDetails{Next: "next"}},
+		{"ResponsePagePrevNext", getResponseBodyPage(TestStruct{"blah"}, &PageDetails{"prev", "next"}), false, "blah", &PageDetails{Prev: "prev", Next: "next"}},
+		{"Error", getErrorBody("blah", http.StatusNotFound), true, "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ts TestStruct
+
+			pd, err := ReadResponsePage(tt.r, &ts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+				if ts.Value != tt.wantValue {
+					t.Errorf("got value '%v', want '%v'", ts.Value, tt.wantValue)
+				}
+				if got, want := (pd == nil), (tt.wantPD == nil); got != want {
+					t.Errorf("got nil page %v, want %v", got, want)
+				} else if pd != nil {
+					if got, want := pd.Prev, tt.wantPD.Prev; got != want {
+						t.Errorf("got prev %v, want %v", got, want)
+					}
+					if got, want := pd.Next, tt.wantPD.Next; got != want {
+						t.Errorf("got next %v, want %v", got, want)
+					}
+				}
+			}
+		})
+	}
 }
 
 func TestReadResponse(t *testing.T) {


### PR DESCRIPTION
Add `ResponsePage()` and `WriteResponsePage()`, to support backwards-compatible paging for JSON responses.