### PR TITLE
Go Module and CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,6 @@ jobs:
       - run:
           name: Run Tests
           command: go test -cover -race -timeout 60s ./...
-      - store_artifacts:
-          path: cover.out
-          destination: cover.out
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/sylabs/json-resp
   docker:
-    - image: golang:latest
+    - image: golang:1.12
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 defaults: &defaults
-  working_directory: /go/src/github.com/sylabs/json-resp
+  working_directory: /src
   docker:
     - image: golang:1.12
 
@@ -32,10 +32,24 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
+      - run:
+          name: Populate Go Mod Cache
+          command: |
+            if [ ! -d /go/pkg/mod ]; then
+              go mod download
+            fi
+      - save_cache:
+          key: go-mod-{{ checksum "go.sum" }}
+          paths:
+            - /go/pkg/mod
       - persist_to_workspace:
           root: /
           paths:
-            - go/src/github.com/sylabs/json-resp/*
+            - go/pkg/mod
+            - src
 
   build_source:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,19 @@ jobs:
           name: Check for Lint
           command: golangci-lint run ./...
 
+  lint_markdown:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install markdownlint
+          command: sudo npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint --config src/.markdownlint.json src/
+
   unit_test:
     <<: *defaults
     steps:
@@ -115,6 +128,9 @@ workflows:
           requires:
             - get_source
       - lint_source:
+          requires:
+            - get_source
+      - lint_markdown:
           requires:
             - get_source
       - unit_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
       - run:
           name: Check for Lint
           command: |
-            go get -u golang.org/x/lint/golint
-            golint -set_exit_status `go list ./...`
+            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+            golangci-lint run ./...
       - run:
           name: Run Tests
           command: go test -cover -race -timeout 60s ./...
@@ -84,10 +84,11 @@ jobs:
       - attach_workspace:
           at: /
       - run:
+          name: Install golangci-lint
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+      - run:
           name: Check for Lint
-          command: |
-            go get -u golang.org/x/lint/golint
-            golint -set_exit_status `go list ./...`
+          command: golangci-lint run ./...
 
   unit_test:
     <<: *defaults

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "default": true,
+    "MD013": false
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # JSON Response
 
+[![GoDoc](https://godoc.org/github.com/sylabs/json-resp?status.svg)](https://godoc.org/github.com/sylabs/json-resp)
 [![Build Status](https://circleci.com/gh/sylabs/json-resp.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/json-resp)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/json-resp)](https://goreportcard.com/report/github.com/sylabs/json-resp)
 
 The `json-resp` package contains a small set of functions that are used to marshall and unmarshall response data and errors in JSON format.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # JSON Response
 
-<a href="https://circleci.com/gh/sylabs/workflows/json-resp"><img src="https://circleci.com/gh/sylabs/json-resp.svg?style=shield&circle-token=48bc85b347052f2de57405ab063b0d8b96c7059d"></a>
-<a href="https://app.zenhub.com/workspace/o/sylabs/json-resp/boards"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a>
+[![Build Status](https://circleci.com/gh/sylabs/json-resp.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/json-resp)
 
 The `json-resp` package contains a small set of functions that are used to marshall and unmarshall response data and errors in JSON format.
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sylabs/json-resp
+
+go 1.12

--- a/json_response_test.go
+++ b/json_response_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -57,7 +58,9 @@ func TestWriteError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
 
-			WriteError(rr, tt.error, tt.code)
+			if err := WriteError(rr, tt.error, tt.code); err != nil {
+				t.Fatalf("failed to write error: %v", err)
+			}
 
 			if rr.Code != tt.wantCode {
 				t.Errorf("got code %v, want %v", rr.Code, tt.wantCode)
@@ -110,7 +113,9 @@ func TestWriteResponsePage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
 
-			WriteResponsePage(rr, tt.data, tt.pd, tt.code)
+			if err := WriteResponsePage(rr, tt.data, tt.pd, tt.code); err != nil {
+				t.Fatalf("failed to write response: %v", err)
+			}
 
 			var ts TestStruct
 			pd, err := ReadResponsePage(rr.Body, &ts)
@@ -154,7 +159,9 @@ func TestWriteResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
 
-			WriteResponse(rr, tt.data, tt.code)
+			if err := WriteResponse(rr, tt.data, tt.code); err != nil {
+				t.Fatalf("failed to write response: %v", err)
+			}
 
 			var ts TestStruct
 			if err := ReadResponse(rr.Body, &ts); err != nil {
@@ -172,7 +179,9 @@ func TestWriteResponse(t *testing.T) {
 
 func getResponseBodyPage(v interface{}, p *PageDetails) io.Reader {
 	rr := httptest.NewRecorder()
-	WriteResponsePage(rr, v, p, http.StatusOK)
+	if err := WriteResponsePage(rr, v, p, http.StatusOK); err != nil {
+		log.Fatalf("failed to write response: %v", err)
+	}
 	return rr.Body
 }
 
@@ -182,7 +191,9 @@ func getResponseBody(v interface{}) io.Reader {
 
 func getErrorBody(error string, code int) io.Reader {
 	rr := httptest.NewRecorder()
-	WriteError(rr, error, code)
+	if err := WriteError(rr, error, code); err != nil {
+		log.Fatalf("failed to write error: %v", err)
+	}
 	return rr.Body
 }
 


### PR DESCRIPTION
Declare Go module and add dependency caching in CI workflow. Move source outside of `GOPATH` in CI. Use fixed Golang version in CI. Switch from `golint` to `golangci-lint` and add `markdownlint` in CI. Address lint in source code and README. Add GoDoc and Go Report Card badges.

Closes #6, closes #7, closes #8.