### PR TITLE
Add Func to Read Error

### DIFF
--- a/json_response.go
+++ b/json_response.go
@@ -110,3 +110,18 @@ func ReadResponse(r io.Reader, v interface{}) error {
 	_, err := ReadResponsePage(r, v)
 	return err
 }
+
+// ReadError attempts to unmarshal JSON-encoded error details from the supplied reader. It returns
+// nil if an error could not be parsed from the response, or if the parsed error was nil.
+func ReadError(r io.Reader) error {
+	var u struct {
+		Error *Error `json:"error"`
+	}
+	if err := json.NewDecoder(r).Decode(&u); err != nil {
+		return nil
+	}
+	if u.Error == nil {
+		return nil
+	}
+	return u.Error
+}

--- a/json_response_test.go
+++ b/json_response_test.go
@@ -284,15 +284,14 @@ func TestReadResponseNil(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		r         io.Reader
-		wantErr   bool
-		wantValue string
+		name    string
+		r       io.Reader
+		wantErr bool
 	}{
-		{"Empty", bytes.NewReader(nil), true, ""},
-		{"Nil", getResponseBody(nil), false, "blah"},
-		{"Response", getResponseBody(TestStruct{"blah"}), false, "blah"},
-		{"Error", getErrorBody("blah", http.StatusNotFound), true, ""},
+		{"Empty", bytes.NewReader(nil), true},
+		{"Nil", getResponseBody(nil), false},
+		{"Response", getResponseBody(TestStruct{"blah"}), false},
+		{"Error", getErrorBody("blah", http.StatusNotFound), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/json_response_test.go
+++ b/json_response_test.go
@@ -303,3 +303,42 @@ func TestReadResponseNil(t *testing.T) {
 		})
 	}
 }
+
+func TestReadError(t *testing.T) {
+	type TestStruct struct {
+		Value string
+	}
+
+	tests := []struct {
+		name        string
+		r           io.Reader
+		wantErr     bool
+		wantMessage string
+		wantCode    int
+	}{
+		{"Empty", bytes.NewReader(nil), false, "", 0},
+		{"Response", getResponseBody(TestStruct{"blah"}), false, "", 0},
+		{"Error", getErrorBody("blah", http.StatusNotFound), true, "blah", http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ReadError(tt.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadError() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil {
+				err, ok := err.(*Error)
+				if !ok {
+					t.Fatal("invalid error type")
+				}
+				if got, want := err.Message, tt.wantMessage; got != want {
+					t.Errorf("got message %v, want %v", got, want)
+				}
+				if got, want := err.Code, tt.wantCode; got != want {
+					t.Errorf("got code %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `func ReadError` to assist in parsing detailed error messages. Remove unused struct member in `func TestReadResponseNil`.

Fixes #10 