### PR TITLE
Update to Go v1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,28 +22,10 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
-  cache_go_mod:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Populate Go Mod Cache
-          command: go mod download
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - '/go/pkg/mod'
-
   build_source:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
           command: go build -mod=readonly ./...
@@ -52,9 +34,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
@@ -66,9 +45,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
           command: go test -coverprofile cover.out -race ./...
@@ -81,13 +57,6 @@ workflows:
   build_and_test:
     jobs:
       - lint_markdown
-      - cache_go_mod
-      - build_source:
-          requires:
-            - cache_go_mod
-      - lint_source:
-          requires:
-            - cache_go_mod
-      - unit_test:
-          requires:
-            - cache_go_mod
+      - build_source
+      - lint_source
+      - unit_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   working_directory: /src
   docker:
-    - image: golang:1.12
+    - image: golang:1.13
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.4
+  codecov: codecov/codecov@1.0.5
 
 defaults: &defaults
   working_directory: /src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sylabs/json-resp
 
-go 1.12
+go 1.13


### PR DESCRIPTION
Update to use Go v1.13. Update `golangci-lint` to v1.18.0. Update `codecov` Orb to v1.0.5 version. Remove `cache_go_mod` CI job.

Closes #19 