### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.5
+  codecov: codecov/codecov@1.1.0
 
 defaults: &defaults
   working_directory: /src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,8 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.1.0
 
-defaults: &defaults
-  working_directory: /src
-  docker:
-    - image: golang:1.14
-
 jobs:
   lint_markdown:
-    <<: *defaults
     docker:
       - image: node:14-slim
     steps:
@@ -23,7 +17,8 @@ jobs:
           command: markdownlint .
 
   check_mod_tidy:
-    <<: *defaults
+    docker:
+      - image: golang:1.14
     steps:
       - checkout
       - run:
@@ -33,7 +28,8 @@ jobs:
             git diff --exit-code -- go.mod go.sum
 
   build_source:
-    <<: *defaults
+    docker:
+      - image: golang:1.14
     steps:
       - checkout
       - run:
@@ -41,7 +37,8 @@ jobs:
           command: go build ./...
 
   lint_source:
-    <<: *defaults
+    docker:
+      - image: golang:1.14
     steps:
       - checkout
       - run:
@@ -52,7 +49,8 @@ jobs:
           command: golangci-lint run
 
   unit_test:
-    <<: *defaults
+    docker:
+      - image: golang:1.14
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,23 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
+  check_mod_tidy:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Check Module Tidiness
+          command: |-
+            go mod tidy
+            git diff --exit-code -- go.mod go.sum
+
   build_source:
     <<: *defaults
     steps:
       - checkout
       - run:
           name: Build Source
-          command: go build -mod=readonly ./...
+          command: go build ./...
 
   lint_source:
     <<: *defaults
@@ -57,6 +67,7 @@ workflows:
   build_and_test:
     jobs:
       - lint_markdown
+      - check_mod_tidy
       - build_source
       - lint_source
       - unit_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   lint_markdown:
     <<: *defaults
     docker:
-      - image: node:12-slim
+      - image: node:14-slim
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - checkout
       - run:
           name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.7
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
       - run:
           name: Check for Lint
           command: golangci-lint run


### PR DESCRIPTION
Add `check_mod_tidy` step to check to validate `go.mod` and `go.sum` are tidy. Bump `codecov` orb to 1.1.0, `node` to `14-slim`, and `golangci-lint` to 1.27.0. Remove `defaults` anchor, since `working_directory` is no longer required.