### PR TITLE
Bump Go to 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:14-slim
   golang:
     docker:
-      - image: golang:1.14
+      - image: golang:1.15
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.30-alpine

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sylabs/json-resp
 
-go 1.13
+go 1.14


### PR DESCRIPTION
Upgrade Go to 1.15, and ratchet language version to 1.14 (implying support for two latest versions of Go.)