### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.16
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.30-alpine
+      - image: golangci/golangci-lint:v1.39
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:14-slim
   golang:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.30-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:14-slim
+      - image: node:15-slim
   golang:
     docker:
       - image: golang:1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sylabs/json-resp
 
-go 1.14
+go 1.15


### PR DESCRIPTION
Ratchet Go language version up to 1.15, and test with 1.16 in CI. Bump `golangci-lint` to v1.39, and `node` to v15.