### PR TITLE
Test Against Latest Major Versions of Go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,18 @@ executors:
   node:
     docker:
       - image: node:16-slim
-  golang:
-    docker:
-      - image: golang:1.16
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.41-alpine
+  golang-previous:
+    docker:
+      - image: golang:1.15
+  golang-latest:
+    docker:
+      - image: golang:1.16
 
 jobs:
-  lint_markdown:
+  lint-markdown:
     executor: node
     steps:
       - checkout
@@ -26,8 +29,16 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
-  check_mod_tidy:
-    executor: golang
+  lint-source:
+    executor: golangci-lint
+    steps:
+      - checkout
+      - run:
+          name: Check for Lint
+          command: golangci-lint run
+
+  check-go-mod:
+    executor: golang-latest
     steps:
       - checkout
       - run:
@@ -37,28 +48,26 @@ jobs:
           name: Check Module Tidiness
           command: git diff --exit-code -- go.mod go.sum
 
-  build_source:
-    executor: golang
+  build-source:
+    parameters:
+      e:
+        type: executor
+    executor: << parameters.e >>
     steps:
       - checkout
       - run:
           name: Build Source
           command: go build ./...
 
-  lint_source:
-    executor: golangci-lint
+  unit-test:
+    parameters:
+      e:
+        type: executor
+    executor: << parameters.e >>
     steps:
       - checkout
       - run:
-          name: Check for Lint
-          command: golangci-lint run
-
-  unit_test:
-    executor: golang
-    steps:
-      - checkout
-      - run:
-          name: Run Tests
+          name: Run Unit Tests
           command: go test -coverprofile cover.out -race ./...
       - codecov/upload:
           file: cover.out
@@ -66,10 +75,16 @@ jobs:
 workflows:
   version: 2
 
-  build_and_test:
+  build-and-test:
     jobs:
-      - lint_markdown
-      - check_mod_tidy
-      - build_source
-      - lint_source
-      - unit_test
+      - lint-markdown
+      - lint-source
+      - check-go-mod
+      - build-source:
+          matrix:
+            parameters:
+              e: ["golang-previous", "golang-latest"]
+      - unit-test:
+          matrix:
+            parameters:
+              e: ["golang-previous", "golang-latest"]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@
 
 The `json-resp` package contains a small set of functions that are used to marshall and unmarshall response data and errors in JSON format.
 
-## Quick Start
+## Go Version Compatibility
 
-To build and test:
-
-```sh
-go test ./...
-```
-
-## Continuous Integration
-
-This package uses [CircleCI](https://circleci.com) for Continuous Integration (CI). It runs automatically on commits and pull requests involving a protected branch. All CI checks must pass before a merge to a proected branch can be performed.
+This module aims to maintain support for the two most recent stable versions of Go. This corresponds to the Go [Release Maintenance Policy](https://github.com/golang/go/wiki/Go-Release-Cycle#release-maintenance) and [Security Policy](https://golang.org/security), ensuring critical bug fixes and security patches are available for all supported language versions.


### PR DESCRIPTION
Always test against latest two versions of Go in CI. Re-order and re-name jobs for consistency with other projects. Simplify README, add Go compatibility statement.