### PR TITLE
Bump Go to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.41-alpine
   golang-previous:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golang-latest:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
 
 jobs:
   lint-markdown:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sylabs/json-resp
 
-go 1.15
+go 1.17


### PR DESCRIPTION
Bump `go.mod` language version to 1.17 to take advantage of [lazy loading](https://golang.org/ref/mod#lazy-loading). Bump CI Go version range to 1.16-1.17.