### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.43-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.43-alpine
+      - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,10 @@ linters:
   enable:
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
@@ -12,6 +14,8 @@ linters:
     - funlen
     - gochecknoinits
     - gocognit
+    - errchkjson
+    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
@@ -22,8 +26,10 @@ linters:
     - gosec
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - ireturn
+    - maintidx
     - misspell
     - nakedret
     - nilnil
@@ -39,3 +45,4 @@ linters:
     - unparam
     - unused
     - varcheck
+    - whitespace

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
 # LICENSE
 
+Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 

--- a/json_response.go
+++ b/json_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.

--- a/json_response_test.go
+++ b/json_response_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.


### PR DESCRIPTION
Bump `node` to v17, and `golangci-lint` to v1.44. Fix a few out-of-date copyright lines.