### PR TITLE
Update CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:20-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.55
+      - image: golangci/golangci-lint:v1.59
   golang-previous:
     docker:
       - image: golang:1.20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.59
   golang-previous:
     docker:
-      - image: golang:1.20
+      - image: golang:1.21
   golang-latest:
     docker:
-      - image: golang:1.21
+      - image: golang:1.22
 
 jobs:
   lint-markdown:


### PR DESCRIPTION
- Bump Go version
- Bump `golangci-lint` to v1.59